### PR TITLE
fix(): False positives against speed hacks and countermeasures

### DIFF
--- a/src/AnticheatData.cpp
+++ b/src/AnticheatData.cpp
@@ -27,6 +27,7 @@
 AnticheatData::AnticheatData()
 {
     lastOpcode = 0;
+    lastSpeedRate = 0.0f;
     totalReports = 0;
     for (uint8 i = 0; i < MAX_REPORT_TYPES; i++)
     {
@@ -34,13 +35,21 @@ AnticheatData::AnticheatData()
         tempReports[i] = 0;
         tempReportsTimer[i] = 0;
     }
-    average = 0;
+    average = 0.0f;
     creationTime = 0;
     hasDailyReport = false;
+    justUsedMovementSpell = false;
 }
 
 AnticheatData::~AnticheatData()
 {
+}
+
+void AnticheatData::SetLastInformations(MovementInfo movementInfo, uint32 opcode, float speedRate)
+{
+    SetLastMovementInfo(movementInfo);
+    SetLastOpcode(opcode);
+    SetLastSpeedRate(speedRate);
 }
 
 void AnticheatData::SetDailyReportState(bool b)

--- a/src/AnticheatData.h
+++ b/src/AnticheatData.h
@@ -35,11 +35,16 @@ public:
     AnticheatData();
     ~AnticheatData();
 
+    void SetLastInformations(MovementInfo movementInfo, uint32 opcode, float speedRate);
+
     void SetLastOpcode(uint32 opcode);
     uint32 GetLastOpcode() const;
 
     const MovementInfo& GetLastMovementInfo() const;
     void SetLastMovementInfo(MovementInfo& moveInfo);
+
+    [[nodiscard]] float GetLastSpeedRate() const { return lastSpeedRate; }
+    void SetLastSpeedRate(float speedRate) { lastSpeedRate = speedRate; }
 
     void SetPosition(float x, float y, float z, float o);
 
@@ -63,9 +68,13 @@ public:
 
     void SetDailyReportState(bool b);
     bool GetDailyReportState();
+
+    [[nodiscard]] bool GetJustUsedMovementSpell() const { return justUsedMovementSpell; }
+    void SetJustUsedMovementSpell(bool value) { justUsedMovementSpell = value; }
 private:
     uint32 lastOpcode;
     MovementInfo lastMovementInfo;
+    float lastSpeedRate;
     uint32 totalReports;
     uint32 typeReports[MAX_REPORT_TYPES];
     float average;
@@ -73,6 +82,7 @@ private:
     uint32 tempReports[MAX_REPORT_TYPES];
     uint32 tempReportsTimer[MAX_REPORT_TYPES];
     bool hasDailyReport;
+    bool justUsedMovementSpell;
 };
 
 #endif

--- a/src/AnticheatMgr.cpp
+++ b/src/AnticheatMgr.cpp
@@ -41,6 +41,12 @@ constexpr auto ALLOWED_ACK_LAG = 2000;
 
 enum Spells : uint32
 {
+    BLINK = 1953u,
+    BLINK_COOLDOWN_REDUCTION = 23025u,      // Reduces Blink cooldown by 2 seconds.
+    GLYPH_OF_BLINK = 56365u,                // Increases Blink distance by 5 yards.
+    SHADOWSTEP = 36554u,
+    FILTHY_TRICKS_RANK_1 = 58414u,          // Reduces Shadowstep cooldown by 5 seconds.
+    FILTHY_TRICKS_RANK_2 = 58415u,          // Reduces Shadowstep cooldown by 10 seconds.
     SHACKLES = 38505,
     LFG_SPELL_DUNGEON_DESERTER = 71041,
     BG_SPELL_DESERTER = 26013,
@@ -93,8 +99,7 @@ void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo,
 
     if (player->IsInFlight() || player->GetTransport() || player->GetVehicle())
     {
-        m_Players[key].SetLastMovementInfo(movementInfo);
-        m_Players[key].SetLastOpcode(opcode);
+        m_Players[key].SetLastInformations(movementInfo, opcode, GetPlayerCurrentSpeedRate(player));
         return;
     }
 
@@ -127,8 +132,64 @@ void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo,
             BGStartExploit(player, movementInfo);
         }
     }
-    m_Players[key].SetLastMovementInfo(movementInfo);
-    m_Players[key].SetLastOpcode(opcode);
+    m_Players[key].SetLastInformations(movementInfo, opcode, GetPlayerCurrentSpeedRate(player));
+}
+
+uint32 AnticheatMgr::GetTeleportSkillCooldownDurationInMS(Player* player) const
+{
+    switch (player->getClass())
+    {
+        case CLASS_ROGUE:
+            if (player->HasAura(FILTHY_TRICKS_RANK_2))
+                return 20000u;
+            else if (player->HasAura(FILTHY_TRICKS_RANK_1))
+                return 25000u;
+            else
+                return 30000u;
+        case CLASS_MAGE:
+            if (player->HasAura(BLINK_COOLDOWN_REDUCTION)) // Bonus from Vanilla/Early TBC pvp gear.
+                return 13000u;
+            else
+                return 15000u;
+        default:
+            return 0u;
+    }
+}
+
+float AnticheatMgr::GetTeleportSkillDistanceInYards(Player* player) const
+{
+    switch (player->getClass())
+    {
+        case CLASS_ROGUE: // The rogue's teleport spell is Shadowstep.
+            return 25.0f; // Synful-Syn: Help needed! At least, 25 yards adjustment is better than nothing!
+            // The spell can be casted at a maximum of 25 yards from the middle of the ennemy and teleports the player a short distance behind the target which might be over 25 yards, especially when the target is facing the rogue.
+            // Using Shadowstep on Onyxia at as far as I could moved me by 44 yards. Doing it on a blood elf in duel moved me 29 yards.
+        case CLASS_MAGE: // The mage's teleport spell is Blink.
+            if (player->HasAura(GLYPH_OF_BLINK))
+                return 25.1f; // Includes a 0.1 miscalculation margin.
+            else
+                return 20.1f; // Includes a 0.1 miscalculation margin.
+        default:
+            return 0.0f;
+    }
+}
+
+// Get how many yards the player can move in a second.
+float AnticheatMgr::GetPlayerCurrentSpeedRate(Player* player) const
+{
+    // we need to know HOW is the player moving
+    // TO-DO: Should we check the incoming movement flags?
+    UnitMoveType moveType;
+    if (player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
+        moveType = MOVE_SWIM;
+    else if (player->IsFlying())
+        moveType = MOVE_FLIGHT;
+    else if (player->HasUnitMovementFlag(MOVEMENTFLAG_WALKING))
+        moveType = MOVE_WALK;
+    else
+        moveType = MOVE_RUN;
+
+    return player->GetSpeed(moveType);
 }
 
 void AnticheatMgr::SpeedHackDetection(Player* player, MovementInfo movementInfo)
@@ -179,31 +240,19 @@ void AnticheatMgr::SpeedHackDetection(Player* player, MovementInfo movementInfo)
         }
     }
 
-    uint32 distance2D = (uint32)movementInfo.pos.GetExactDist2d(&m_Players[key].GetLastMovementInfo().pos);
+    float distance2D = movementInfo.pos.GetExactDist2d(&m_Players[key].GetLastMovementInfo().pos);
 
     // We don't need to check for a speedhack if the player hasn't moved
     // This is necessary since MovementHandler fires if you rotate the camera in place
     if (!distance2D)
         return;
 
-    // we need to know HOW is the player moving
-    // TO-DO: Should we check the incoming movement flags?
-    UnitMoveType moveType;
-    if (player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
-        moveType = MOVE_SWIM;
-    else if (player->IsFlying())
-        moveType = MOVE_FLIGHT;
-    else if (player->HasUnitMovementFlag(MOVEMENTFLAG_WALKING))
-        moveType = MOVE_WALK;
-    else
-        moveType = MOVE_RUN;
-
-    // how many yards the player can do in one sec.
-    // We remove the added speed for jumping because otherwise permanently jumping doubles your allowed speed
-    uint32 speedRate = (uint32)(player->GetSpeed(moveType));
-
     // how long the player took to move to here.
     uint32 timeDiff = getMSTimeDiff(m_Players[key].GetLastMovementInfo().time, movementInfo.time);
+
+    float speedRate = GetPlayerCurrentSpeedRate(player);
+    if (timeDiff <= ALLOWED_ACK_LAG)
+        speedRate = std::max(speedRate, m_Players[key].GetLastSpeedRate()); // The player might have been moving with a previously faster speed. This should help mitigate a false positive from loosing a speed increase buff.
 
     if (int32(timeDiff) < 0 && sConfigMgr->GetOption<bool>("Anticheat.CM.TIMEMANIPULATION", true))
     {
@@ -257,19 +306,38 @@ void AnticheatMgr::SpeedHackDetection(Player* player, MovementInfo movementInfo)
         BuildReport(player, COUNTER_MEASURES_REPORT);
     }
 
+    // Adjust distance from Blink/Shadowstep.
+    if (player->HasAura(BLINK) || player->HasAura(SHADOWSTEP))
+    {
+        // Only adjust the travelled distance if the player previously didn't use a movement spell or didn't move at all since they previously used the movement spell.
+        if (!m_Players[key].GetJustUsedMovementSpell() || timeDiff >= GetTeleportSkillCooldownDurationInMS(player))
+        {
+            m_Players[key].SetJustUsedMovementSpell(true);
+            distance2D = std::max(distance2D - GetTeleportSkillDistanceInYards(player), 0.0f);
+        }
+    }
+    else
+    {
+        m_Players[key].SetJustUsedMovementSpell(false);
+    }
+
     // this is the distance doable by the player in 1 sec, using the time done to move to this point.
-    uint32 clientSpeedRate = distance2D * 1000 / timeDiff;
+    float clientSpeedRate;
+    if (float floatTimeDiff = float(timeDiff))
+        clientSpeedRate = distance2D * 1000.0f / floatTimeDiff;
+    else
+        clientSpeedRate = 0.0f;
 
     // we create a diff speed in uint32 for further precision checking to avoid legit fall and slide
-    uint32 diffspeed = clientSpeedRate - speedRate;
+    float diffspeed = clientSpeedRate - speedRate;
 
     // create a conf to establish a speed limit tolerance over server rate set speed
     // this is done so we can ignore minor violations that are not false positives such as going 1 or 2 over the speed limit
-    _assignedspeeddiff = sConfigMgr->GetOption<uint32>("Anticheat.SpeedLimitTolerance", 0);
+    float assignedspeeddiff = sConfigMgr->GetOption<float>("Anticheat.SpeedLimitTolerance", 0.0f);
 
     // We did the (uint32) cast to accept a margin of tolerance for seasonal spells and buffs such as sugar rush
     // We check the last MovementInfo for the falling flag since falling down a hill and sliding a bit triggered a false positive
-    if ((diffspeed >= _assignedspeeddiff) && !m_Players[key].GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_FALLING))
+    if ((diffspeed >= assignedspeeddiff) && !m_Players[key].GetLastMovementInfo().HasMovementFlag(MOVEMENTFLAG_FALLING))
     {
         if (clientSpeedRate > speedRate * 1.05f)
         {

--- a/src/AnticheatMgr.cpp
+++ b/src/AnticheatMgr.cpp
@@ -41,12 +41,12 @@ constexpr auto ALLOWED_ACK_LAG = 2000;
 
 enum Spells : uint32
 {
-    BLINK = 1953u,
-    BLINK_COOLDOWN_REDUCTION = 23025u,      // Reduces Blink cooldown by 2 seconds.
-    GLYPH_OF_BLINK = 56365u,                // Increases Blink distance by 5 yards.
-    SHADOWSTEP = 36554u,
-    FILTHY_TRICKS_RANK_1 = 58414u,          // Reduces Shadowstep cooldown by 5 seconds.
-    FILTHY_TRICKS_RANK_2 = 58415u,          // Reduces Shadowstep cooldown by 10 seconds.
+    BLINK = 1953,
+    BLINK_COOLDOWN_REDUCTION = 23025,       // Reduces Blink cooldown by 2 seconds.
+    GLYPH_OF_BLINK = 56365,                 // Increases Blink distance by 5 yards.
+    SHADOWSTEP = 36554,
+    FILTHY_TRICKS_RANK_1 = 58414,           // Reduces Shadowstep cooldown by 5 seconds.
+    FILTHY_TRICKS_RANK_2 = 58415,           // Reduces Shadowstep cooldown by 10 seconds.
     SHACKLES = 38505,
     LFG_SPELL_DUNGEON_DESERTER = 71041,
     BG_SPELL_DESERTER = 26013,
@@ -144,13 +144,11 @@ uint32 AnticheatMgr::GetTeleportSkillCooldownDurationInMS(Player* player) const
                 return 20000u;
             else if (player->HasAura(FILTHY_TRICKS_RANK_1))
                 return 25000u;
-            else
-                return 30000u;
+            return 30000u;
         case CLASS_MAGE:
             if (player->HasAura(BLINK_COOLDOWN_REDUCTION)) // Bonus from Vanilla/Early TBC pvp gear.
                 return 13000u;
-            else
-                return 15000u;
+            return 15000u;
         default:
             return 0u;
     }
@@ -167,8 +165,7 @@ float AnticheatMgr::GetTeleportSkillDistanceInYards(Player* player) const
         case CLASS_MAGE: // The mage's teleport spell is Blink.
             if (player->HasAura(GLYPH_OF_BLINK))
                 return 25.1f; // Includes a 0.1 miscalculation margin.
-            else
-                return 20.1f; // Includes a 0.1 miscalculation margin.
+            return 20.1f; // Includes a 0.1 miscalculation margin.
         default:
             return 0.0f;
     }
@@ -179,17 +176,13 @@ float AnticheatMgr::GetPlayerCurrentSpeedRate(Player* player) const
 {
     // we need to know HOW is the player moving
     // TO-DO: Should we check the incoming movement flags?
-    UnitMoveType moveType;
     if (player->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING))
-        moveType = MOVE_SWIM;
+        return player->GetSpeed(MOVE_SWIM);
     else if (player->IsFlying())
-        moveType = MOVE_FLIGHT;
+        return player->GetSpeed(MOVE_FLIGHT);
     else if (player->HasUnitMovementFlag(MOVEMENTFLAG_WALKING))
-        moveType = MOVE_WALK;
-    else
-        moveType = MOVE_RUN;
-
-    return player->GetSpeed(moveType);
+        return player->GetSpeed(MOVE_WALK);
+    return player->GetSpeed(MOVE_RUN);
 }
 
 void AnticheatMgr::SpeedHackDetection(Player* player, MovementInfo movementInfo)
@@ -322,11 +315,9 @@ void AnticheatMgr::SpeedHackDetection(Player* player, MovementInfo movementInfo)
     }
 
     // this is the distance doable by the player in 1 sec, using the time done to move to this point.
-    float clientSpeedRate;
+    float clientSpeedRate = 0.0f;
     if (float floatTimeDiff = float(timeDiff))
         clientSpeedRate = distance2D * 1000.0f / floatTimeDiff;
-    else
-        clientSpeedRate = 0.0f;
 
     // we create a diff speed in uint32 for further precision checking to avoid legit fall and slide
     float diffspeed = clientSpeedRate - speedRate;

--- a/src/AnticheatMgr.h
+++ b/src/AnticheatMgr.h
@@ -131,9 +131,11 @@ class AnticheatMgr
         void BGStartExploit(Player* player, MovementInfo movementInfo);
         void BuildReport(Player* player, ReportTypes reportType);
         bool MustCheckTempReports(ReportTypes type);
+        [[nodiscard]] uint32 GetTeleportSkillCooldownDurationInMS(Player* player) const;
+        [[nodiscard]] float GetTeleportSkillDistanceInYards(Player* player) const;
+        [[nodiscard]] float GetPlayerCurrentSpeedRate(Player* player) const;
         uint32 _counter = 0;
         uint32 _alertFrequency = 0;
-        uint32 _assignedspeeddiff = 0;
         uint32 _updateCheckTimer = 4000;
         uint32 m_MapId;
         std::array<Position, PVP_TEAMS_COUNT> _startPosition;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Improvement against a speed hack false positive because the server was expecting the player to be moving at a slower speed before the player knew they had to move slower such as the loss of a speed increase buff or receiving a slow debuff.
- Fix against speed hack false positive by using the `Blink` spell by adjusting the traveled distance (20.1y or 25.1y glyphed, includes a miscalculation adjustments).
- Fix against speed hack false positive by using the `Shadowstep` (25y only) spell by adjusting the traveled distance.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-anticheat/issues/110
- Fixes the speed hack false positive from https://github.com/azerothcore/mod-anticheat/issues/111

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tried to reproduce the false positives in the issues above.
- Using `Shadowstep` no longer trigger the speed hack false positives at mid range.
- Running forward and getting `Dazed` is now very difficult to trigger the speed hack false positive.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. You may use the following configs.
```
Anticheat.EnabledOnGmAccounts = 1
Anticheat.ReportsForIngameWarnings = 1
Anticheat.ReportinChat.Min = 1
Anticheat.ReportinChat.Max = 8000
Anticheat.StricterFlyHackCheck = 1
Anticheat.StricterDetectJumpHack = 1
Anticheat.SpeedLimitTolerance = 0
Anticheat.CM.TIMEMANIPULATION = 1
Anticheat.CM.Teleport = 1
Anticheat.CM.FLYHACK = 1
Anticheat.CM.JUMPHACK = 1
Anticheat.CM.ADVJUMPHACK = 1
Anticheat.CM.IGNOREZ = 1
Anticheat.CM.SPEEDHACK = 1
Anticheat.BG.StartAreaTeleport = 1
Anticheat.CM.ALERTSCREEN = 1
Anticheat.CM.ALERTCHAT = 1
```

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- Complete the logic about how far the `Shadowstep` can go because it will still trigger if you try on Onyxia at max range.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
