### PR TITLE
Fix speed false positive from entering/leaving an instance

### DIFF
--- a/src/AnticheatData.cpp
+++ b/src/AnticheatData.cpp
@@ -45,10 +45,11 @@ AnticheatData::~AnticheatData()
 {
 }
 
-void AnticheatData::SetLastInformations(MovementInfo movementInfo, uint32 opcode, float speedRate)
+void AnticheatData::SetLastInformations(MovementInfo movementInfo, uint32 opcode, uint32 mapId, float speedRate)
 {
     SetLastMovementInfo(movementInfo);
     SetLastOpcode(opcode);
+    SetLastMapId(mapId);
     SetLastSpeedRate(speedRate);
 }
 
@@ -67,9 +68,10 @@ void AnticheatData::SetLastOpcode(uint32 opcode)
     lastOpcode = opcode;
 }
 
-void AnticheatData::SetPosition(float x, float y, float z, float o)
+void AnticheatData::SetPosition(float x, float y, float z, float o, uint32 mapId)
 {
     lastMovementInfo.pos = { x, y, z, o };
+    SetLastMapId(mapId);
 }
 
 uint32 AnticheatData::GetLastOpcode() const

--- a/src/AnticheatData.h
+++ b/src/AnticheatData.h
@@ -35,7 +35,7 @@ public:
     AnticheatData();
     ~AnticheatData();
 
-    void SetLastInformations(MovementInfo movementInfo, uint32 opcode, float speedRate);
+    void SetLastInformations(MovementInfo movementInfo, uint32 opcode, uint32 mapId, float speedRate);
 
     void SetLastOpcode(uint32 opcode);
     uint32 GetLastOpcode() const;
@@ -43,10 +43,13 @@ public:
     const MovementInfo& GetLastMovementInfo() const;
     void SetLastMovementInfo(MovementInfo& moveInfo);
 
+    [[nodiscard]] uint32 GetLastMapId() const { return lastMapId; }
+    void SetLastMapId(float mapId) { lastMapId = mapId; }
+
     [[nodiscard]] float GetLastSpeedRate() const { return lastSpeedRate; }
     void SetLastSpeedRate(float speedRate) { lastSpeedRate = speedRate; }
 
-    void SetPosition(float x, float y, float z, float o);
+    void SetPosition(float x, float y, float z, float o, uint32 mapId);
 
     uint32 GetTotalReports() const;
     void SetTotalReports(uint32 _totalReports);
@@ -74,6 +77,7 @@ public:
 private:
     uint32 lastOpcode;
     MovementInfo lastMovementInfo;
+    uint32 lastMapId;
     float lastSpeedRate;
     uint32 totalReports;
     uint32 typeReports[MAX_REPORT_TYPES];

--- a/src/AnticheatMgr.h
+++ b/src/AnticheatMgr.h
@@ -111,8 +111,6 @@ class AnticheatMgr
         void AnticheatDeleteCommand(ObjectGuid guid);
         void AnticheatPurgeCommand(ChatHandler* handler);
         void ResetDailyReportStates();
-        void SetMapId(uint32 MapID) { m_MapId = MapID; }
-        [[nodiscard]] uint32 GetMapId() const { return m_MapId; }
 
     private:
         void SpeedHackDetection(Player* player, MovementInfo movementInfo);
@@ -144,7 +142,6 @@ class AnticheatMgr
         [[nodiscard]] float GetTeleportSkillDistanceInYards(Player* player) const;
         [[nodiscard]] float GetPlayerCurrentSpeedRate(Player* player) const;
         uint32 _updateCheckTimer = 4000;
-        uint32 m_MapId;
         std::array<Position, PVP_TEAMS_COUNT> _startPosition;
         Position const* GetTeamStartPosition(TeamId teamId) const;
         AnticheatPlayersDataMap m_Players;                        ///< Player data


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Tracks the player's previous mapid so it would no longer trigger speed false positive from repeatedly entering/leaving an instance such as Gnomeregan.
- Remove the silly same X-axis ignore condition in the teleport hack detection: It would be bad to ignore someone using a teleport hack by changing only the Y-axis because the X-axis hasn't changed.
- Remove unused tracking of the mapid from the `AnticheatMgr.h` file because this file it is not related to the current player.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none, I didn't open an issue about it. This video is without any changes on https://github.com/azerothcore/mod-anticheat/commit/05b45c3844c85267aaf4e6c40bc8022068103a66

https://github.com/azerothcore/mod-anticheat/assets/22718174/1794197b-7547-484b-9382-ed34df07d006

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Can no longer reproduce the video above.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Pain! Suffering!
2. `.anticheat player`

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
