### PR TITLE
fix(): Ensure teleport reports always shows coordinates for the chatbox alerts

### DIFF
--- a/src/AnticheatMgr.h
+++ b/src/AnticheatMgr.h
@@ -126,17 +126,17 @@ class AnticheatMgr
         void AntiSwimHackDetection(Player* player, MovementInfo movementInfo, uint32 opcode);
         void AntiKnockBackHackDetection(Player* player, MovementInfo movementInfo);
         void NoFallDamageDetection(Player* player, MovementInfo movementInfo);
-        void BGreport(Player* player);
-        void CheckStartPositions(Player* player);
+        void BGreport(Player* player, MovementInfo movementInfo);
+        void CheckStartPositions(Player* player, MovementInfo movementInfo);
         void BGStartExploit(Player* player, MovementInfo movementInfo);
-        void BuildReport(Player* player, ReportTypes reportType);
+        void BuildReport(Player* player, ReportTypes reportType, Optional<MovementInfo> optMovementInfo);
         bool MustCheckTempReports(ReportTypes type);
         void SendMiddleScreenGMMessage(std::string str);
 
         [[nodiscard]] uint32 GetAlertFrequencyConfigFromReportType(ReportTypes reportType);
         [[nodiscard]] uint32 GetMinimumReportInChatThresholdConfigFromReportType(ReportTypes reportType);
         [[nodiscard]] uint32 GetMaximumReportInChatThresholdConfigFromReportType(ReportTypes reportType);
-        void BuildAndSendReportToIngameGameMasters(Player* player, ReportTypes reportType);
+        void BuildAndSendReportToIngameGameMasters(Player* player, ReportTypes reportType, Optional<MovementInfo> optMovementInfo);
 
         [[nodiscard]] uint32 GetTeleportSkillCooldownDurationInMS(Player* player) const;
         [[nodiscard]] float GetTeleportSkillDistanceInYards(Player* player) const;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Made `BuildAndSendReportToIngameGameMasters` use the `LANG_ANTICHEAT_TELEPORT` and `LANG_ANTICHEAT_IGNORECONTROL` chatbox alerts when the report type are teleport or ignore control respectively. This ensure that every teleport alerts shows what was the coordinates diffs.
- Remove a duplicate teleport alert.
- Remove a duplicate ignore control alert.
- Remove a duplicate Z-Axis alert.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes none. I wanted to always have the coordinates differences whenever someone got detected from teleports.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Doing `.mod speed 50` and running in a straight line without GM mode will wrongly trigger the teleport detection.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
